### PR TITLE
Fix a pair in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ pairs = client.public.asset_pairs
 ##### Ticker Information
 
 ```ruby
-ticker_data = client.public.ticker('ETHXBT, XBTLTC')
+ticker_data = client.public.ticker('ETHXBT, LTCXBT')
 ```
 
 ##### Order Book


### PR DESCRIPTION
The example code is not showing data for the two pairs, because the second one is wrong.