### PR TITLE
only parse response if status is 200

### DIFF
--- a/lib/kraken_client/endpoints/public.rb
+++ b/lib/kraken_client/endpoints/public.rb
@@ -8,7 +8,7 @@ module KrakenClient
           hash = JSON.parse(response.body).with_indifferent_access
           return hash[:result]
         end
-        return nil
+        raise KrakenClient::Exception, "Response status #{response.status} received."
       end
 
       def data

--- a/lib/kraken_client/endpoints/public.rb
+++ b/lib/kraken_client/endpoints/public.rb
@@ -4,8 +4,11 @@ module KrakenClient
 
       def perform(endpoint_name, args)
         response = request_manager.call(url(endpoint_name), args)
-        hash = JSON.parse(response.body).with_indifferent_access
-        hash[:result]
+        if response.status == 200
+          hash = JSON.parse(response.body).with_indifferent_access
+          return hash[:result]
+        end
+        return nil
       end
 
       def data


### PR DESCRIPTION
Kraken, on busy times, can give a 504(or 5xx) gateway error. Without this guard, the code will buff.

It can return nil or [] for a default response. Not fuss