### PR TITLE
Fix error : NoMethodError: undefined method `status' for #<HTTParty::Response:XXX>

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    kraken_client (1.2.1)
+    kraken_client (1.3.0)
       activesupport (>= 3.2)
       addressabler
       httparty
@@ -9,11 +9,10 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (4.2.6)
+    activesupport (5.1.4)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (~> 0.7)
-      json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
-      thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     addressable (2.4.0)
     addressabler (0.1.2)
@@ -21,16 +20,17 @@ GEM
     codeclimate-test-reporter (0.5.0)
       simplecov (>= 0.7.1, < 1.0.0)
     coderay (1.1.1)
+    concurrent-ruby (1.0.5)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     hashdiff (0.3.0)
-    httparty (0.15.5)
+    httparty (0.15.6)
       multi_xml (>= 0.5.2)
-    i18n (0.8.1)
-    json (1.8.6)
+    i18n (0.9.1)
+      concurrent-ruby (~> 1.0)
     matchi (0.0.9)
     method_source (0.8.2)
-    minitest (5.10.2)
+    minitest (5.10.3)
     multi_json (1.12.1)
     multi_xml (0.6.0)
     pry (0.10.3)
@@ -47,14 +47,14 @@ GEM
     spectus (2.3.1)
       matchi (~> 0.0)
     thread_safe (0.3.6)
-    tzinfo (1.2.3)
+    tzinfo (1.2.4)
       thread_safe (~> 0.1)
     vcr (3.0.3)
     webmock (2.0.3)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
-    yard (0.8.7.6)
+    yard (0.9.12)
 
 PLATFORMS
   ruby
@@ -69,7 +69,7 @@ DEPENDENCIES
   spectus (~> 2.3.1)
   vcr
   webmock
-  yard (~> 0.8)
+  yard (~> 0.9.11)
 
 BUNDLED WITH
-   1.14.5
+   1.15.3

--- a/lib/kraken_client/endpoints/public.rb
+++ b/lib/kraken_client/endpoints/public.rb
@@ -4,11 +4,11 @@ module KrakenClient
 
       def perform(endpoint_name, args)
         response = request_manager.call(url(endpoint_name), args)
-        if response.status == 200
+        if response.success?
           hash = JSON.parse(response.body).with_indifferent_access
           return hash[:result]
         end
-        raise KrakenClient::Exception, "Response status #{response.status} received."
+        raise KrakenClient::Exception, "Response code #{response.code} received."
       end
 
       def data


### PR DESCRIPTION
Hi, 

I just tried your gem and I faced an issue when quering the public endpoints. 
I got a `NoMethodError: undefined method 'status' for #<HTTParty::Response:0x0000000004599e68>`

It seems that the response status is get with the `code`method. 
If I'm not wrong, then here is a fix :-)

Also the Gemfile.lock seemed to be outdated 

Regards,

Nico