### PR TITLE
response.status changed to response.code

### DIFF
--- a/lib/kraken_client/endpoints/public.rb
+++ b/lib/kraken_client/endpoints/public.rb
@@ -4,11 +4,11 @@ module KrakenClient
 
       def perform(endpoint_name, args)
         response = request_manager.call(url(endpoint_name), args)
-        if response.status == 200
+        if response.code == 200
           hash = JSON.parse(response.body).with_indifferent_access
           return hash[:result]
         end
-        raise KrakenClient::Exception, "Response status #{response.status} received."
+        raise KrakenClient::Exception, "Response status #{response.code} received."
       end
 
       def data


### PR DESCRIPTION
Thank you for your implementation of kraken_client.  I am using it to connect a private rails accounting application to Kraken.  When I installed your gem, it failed.

It appears that the latest release, 0.16.0, of httparty uses response.code rather than response.status to return the status code.  I made this tiny bug fix and it seems to be properly working now.   Please let me know if I need to do anything else.

Thanks again,

Michael