### PR TITLE
'status' method changed to 'code' for public api calls

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    kraken_client (1.2.1)
+    kraken_client (1.3.0)
       activesupport (>= 3.2)
       addressabler
       httparty
@@ -9,11 +9,10 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (4.2.6)
-      i18n (~> 0.7)
-      json (~> 1.7, >= 1.7.7)
+    activesupport (5.2.2)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
       minitest (~> 5.1)
-      thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     addressable (2.4.0)
     addressabler (0.1.2)
@@ -21,16 +20,21 @@ GEM
     codeclimate-test-reporter (0.5.0)
       simplecov (>= 0.7.1, < 1.0.0)
     coderay (1.1.1)
+    concurrent-ruby (1.1.4)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     hashdiff (0.3.0)
-    httparty (0.15.5)
+    httparty (0.16.4)
+      mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
-    i18n (0.8.1)
-    json (1.8.6)
+    i18n (1.5.3)
+      concurrent-ruby (~> 1.0)
     matchi (0.0.9)
     method_source (0.8.2)
-    minitest (5.10.2)
+    mime-types (3.2.2)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2018.0812)
+    minitest (5.11.3)
     multi_json (1.12.1)
     multi_xml (0.6.0)
     pry (0.10.3)
@@ -47,14 +51,14 @@ GEM
     spectus (2.3.1)
       matchi (~> 0.0)
     thread_safe (0.3.6)
-    tzinfo (1.2.3)
+    tzinfo (1.2.5)
       thread_safe (~> 0.1)
     vcr (3.0.3)
     webmock (2.0.3)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
-    yard (0.8.7.6)
+    yard (0.9.18)
 
 PLATFORMS
   ruby
@@ -69,7 +73,7 @@ DEPENDENCIES
   spectus (~> 2.3.1)
   vcr
   webmock
-  yard (~> 0.8)
+  yard (~> 0.9.11)
 
 BUNDLED WITH
-   1.14.5
+   1.16.1

--- a/lib/kraken_client/endpoints/public.rb
+++ b/lib/kraken_client/endpoints/public.rb
@@ -4,11 +4,11 @@ module KrakenClient
 
       def perform(endpoint_name, args)
         response = request_manager.call(url(endpoint_name), args)
-        if response.status == 200
+        if response.code == 200
           hash = JSON.parse(response.body).with_indifferent_access
           return hash[:result]
         end
-        raise KrakenClient::Exception, "Response status #{response.status} received."
+        raise KrakenClient::Exception, "Response status #{response.code} received."
       end
 
       def data


### PR DESCRIPTION
`NoMethodError: undefined method status for #<HTTParty::Response>` hotfix